### PR TITLE
Fluent API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "illuminate/support": "^7.2",
         "symfony/process": ">4.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR introduces the following changes:

- Add fluent interface for input and output
- Allow passing the content directly from the fluent interface
- Use an empty array when no parameters are passed

```php
$pandoc->fromMarkdown('# h1')->toHtml('index.html')->execute();
````