### PR TITLE
Allow setting working directory for pandoc process

### DIFF
--- a/src/Pandoc.php
+++ b/src/Pandoc.php
@@ -31,6 +31,8 @@ class Pandoc
 
     protected $dataDir;
 
+    protected $workDir;
+
     public function __construct($config = [])
     {
         $this->config = array_merge([
@@ -87,6 +89,13 @@ class Pandoc
         return $this;
     }
 
+    public function workDir($value)
+    {
+        $this->workDir = $value;
+
+        return $this;
+    }
+    
     public function execute(array $parameters = [])
     {
         $parameters = array_merge([
@@ -103,6 +112,10 @@ class Pandoc
 
         $process = new Process($parameters);
 
+        if ($this->workDir) {
+            $process->setWorkingDirectory($workDir);
+        }
+        
         if ($this->input) {
             $process->setInput($this->input);
         }


### PR DESCRIPTION
This PR adds the option to specify the working directory for the pandoc process. Like so:

```php
(new Pandoc\Pandoc)->workDir($directory_path_here)->from(... // and so on...
```

This was prompted by a permissions issue I ran into in my particular use case - which could be solved by changing the working directory to one where the user running this process has guaranteed permissions.

Thanks for your work on this great library.