### PR TITLE
More Specific "not found" Exception Matching

### DIFF
--- a/src/Pandoc.php
+++ b/src/Pandoc.php
@@ -178,7 +178,7 @@ class Pandoc
                 throw new UnknownOutputFormat;
             }
 
-            if (strpos($output, 'not found') !== false) {
+            if (strpos($output, ': not found') !== false) {
                 throw new PandocNotFound;
             }
 


### PR DESCRIPTION
This PR adds a more specific string to match not found exceptions. Currently if pandoc exits with an error message such as:

```
...
! LaTeX Error: File `Lato.sty' not found.
...
```

This is incorrectly converted into a `PandocNotFound` Exception.