### PR TITLE
Add function `noStandalone` to disable `--standalone`

### DIFF
--- a/src/Pandoc.php
+++ b/src/Pandoc.php
@@ -19,6 +19,8 @@ class Pandoc
 
     protected $input;
 
+    protected $standalone = true;
+
     protected $inputFile;
 
     protected $from;
@@ -127,6 +129,14 @@ class Pandoc
     public function standalone()
     {
         $this->option('standalone');
+        $this->standalone = true;
+
+        return $this;
+    }
+
+    public function noStandalone()
+    {
+        $this->standalone = false;
 
         return $this;
     }
@@ -197,9 +207,12 @@ class Pandoc
     public function run()
     {
         $parameters = [
-            '--standalone',
             '--sandbox',
         ];
+
+        if ($this->standalone) {
+            array_push($parameters, '--standalone');
+        }
 
         if ($this->inputFile) {
             array_push($parameters, $this->inputFile);


### PR DESCRIPTION
This implementation keeps backwards-compability by adding `--standalone` in `run()` per default but not adding it per default in `execute()`.

It still can be set explicitely with `standalone()`, resulting in `execute()` passing `--standalone`.

Additionally it can be disabled explicitely with `noStandalone()`, resulting in `run()` not passing `--standalone`.

Fixes: #31

Signed-off-by: Jonas <jonas@freesources.org>